### PR TITLE
Implement JSON-based spell registry

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,9 +62,10 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/scriptmanager.cpp
 	${CMAKE_CURRENT_LIST_DIR}/server.cpp
 	${CMAKE_CURRENT_LIST_DIR}/signals.cpp
-	${CMAKE_CURRENT_LIST_DIR}/spawn.cpp
-	${CMAKE_CURRENT_LIST_DIR}/spells.cpp
-	${CMAKE_CURRENT_LIST_DIR}/storeinbox.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/spawn.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/spells.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/spell_registry.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/storeinbox.cpp
 	${CMAKE_CURRENT_LIST_DIR}/talkaction.cpp
 	${CMAKE_CURRENT_LIST_DIR}/tasks.cpp
 	${CMAKE_CURRENT_LIST_DIR}/teleport.cpp
@@ -150,9 +151,10 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/server.h
 	${CMAKE_CURRENT_LIST_DIR}/signals.h
 	${CMAKE_CURRENT_LIST_DIR}/spawn.h
-	${CMAKE_CURRENT_LIST_DIR}/spectators.h
-	${CMAKE_CURRENT_LIST_DIR}/spells.h
-	${CMAKE_CURRENT_LIST_DIR}/storeinbox.h
+        ${CMAKE_CURRENT_LIST_DIR}/spectators.h
+        ${CMAKE_CURRENT_LIST_DIR}/spells.h
+        ${CMAKE_CURRENT_LIST_DIR}/spell_registry.h
+        ${CMAKE_CURRENT_LIST_DIR}/storeinbox.h
 	${CMAKE_CURRENT_LIST_DIR}/talkaction.h
 	${CMAKE_CURRENT_LIST_DIR}/tasks.h
 	${CMAKE_CURRENT_LIST_DIR}/teleport.h

--- a/src/spell_registry.cpp
+++ b/src/spell_registry.cpp
@@ -1,0 +1,65 @@
+#include "otpch.h"
+
+#include "spell_registry.h"
+
+#include <fstream>
+#include <boost/json/src.hpp>
+
+bool SpellRegistry::loadFromJsonString(std::string_view json)
+{
+    spells.clear();
+    boost::json::value root = boost::json::parse(json);
+    if (!root.is_array()) {
+        return false;
+    }
+    for (const auto& item : root.as_array()) {
+        if (!item.is_object()) {
+            continue;
+        }
+        const auto& obj = item.as_object();
+        SpellDefinition def;
+        if (auto it = obj.if_contains("id")) {
+            def.id = static_cast<uint16_t>(boost::json::value_to<uint64_t>(*it));
+        }
+        if (auto it = obj.if_contains("name")) {
+            def.name = boost::json::value_to<std::string>(*it);
+        }
+        if (auto it = obj.if_contains("words")) {
+            def.words = boost::json::value_to<std::string>(*it);
+        }
+        if (auto it = obj.if_contains("type")) {
+            def.type = boost::json::value_to<std::string>(*it);
+        }
+        if (auto it = obj.if_contains("group")) {
+            def.group = boost::json::value_to<std::string>(*it);
+        }
+        if (auto it = obj.if_contains("level")) {
+            def.level = static_cast<uint32_t>(boost::json::value_to<uint64_t>(*it));
+        }
+        if (auto it = obj.if_contains("mana")) {
+            def.mana = static_cast<uint32_t>(boost::json::value_to<uint64_t>(*it));
+        }
+        spells.emplace(def.id, std::move(def));
+    }
+    return true;
+}
+
+bool SpellRegistry::loadFromJsonFile(const std::string& path)
+{
+    std::ifstream in(path);
+    if (!in.is_open()) {
+        return false;
+    }
+    std::string data((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    return loadFromJsonString(data);
+}
+
+const SpellDefinition* SpellRegistry::getSpell(uint16_t id) const
+{
+    auto it = spells.find(id);
+    if (it == spells.end()) {
+        return nullptr;
+    }
+    return &it->second;
+}
+

--- a/src/spell_registry.h
+++ b/src/spell_registry.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <unordered_map>
+#include <string>
+#include <boost/json.hpp>
+
+struct SpellDefinition {
+    uint16_t id = 0;
+    std::string name;
+    std::string words;
+    std::string type;
+    std::string group;
+    uint32_t level = 0;
+    uint32_t mana = 0;
+};
+
+class SpellRegistry {
+public:
+    bool loadFromJsonFile(const std::string& path);
+    bool loadFromJsonString(std::string_view json);
+
+    const SpellDefinition* getSpell(uint16_t id) const;
+
+private:
+    std::unordered_map<uint16_t, SpellDefinition> spells;
+};
+

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(tests_SRC
     ${CMAKE_CURRENT_LIST_DIR}/test_rsa.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_sha1.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_xtea.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_spell_registry.cpp
     )
 
 foreach(test_src ${tests_SRC})

--- a/src/tests/test_spell_registry.cpp
+++ b/src/tests/test_spell_registry.cpp
@@ -1,0 +1,31 @@
+#define BOOST_TEST_MODULE spell_registry
+
+#include "../otpch.h"
+#include "../spell_registry.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(load_spells_from_json)
+{
+    const std::string json = R"([
+        {
+            "id": 1,
+            "name": "Intense Healing",
+            "words": "exura gran",
+            "type": "instant",
+            "group": "healing",
+            "level": 20,
+            "mana": 70
+        }
+    ])";
+
+    SpellRegistry registry;
+    BOOST_TEST(registry.loadFromJsonString(json));
+    const SpellDefinition* def = registry.getSpell(1);
+    BOOST_REQUIRE(def != nullptr);
+    BOOST_TEST(def->name == "Intense Healing");
+    BOOST_TEST(def->words == "exura gran");
+    BOOST_TEST(def->level == 20u);
+    BOOST_TEST(def->mana == 70u);
+}
+


### PR DESCRIPTION
## Summary
- add `SpellRegistry` for loading spells from JSON
- expose helpers to parse JSON strings and files
- hook new files into build and create tests
- test JSON loader via unit test

## Testing
- `cmake --preset vcpkg -DBUILD_TESTING=ON`
- `cmake --build build --target test_spell_registry`
- `ctest -C Debug --output-on-failure --tests-regex test_spell_registry`


------
https://chatgpt.com/codex/tasks/task_e_684f6694df388332a3c3229f6821e6b1