### PR TITLE
Add alchemy system with config and docs

### DIFF
--- a/data/actions/actions.xml
+++ b/data/actions/actions.xml
@@ -177,4 +177,5 @@
 	<action fromid="18488" toid="18492" script="others/skill_trainer.lua" />
 	<action itemid="20252" script="others/bed_modification_kits.lua" />
 	<action fromid="22845" toid="22846" script="others/teleport.lua" />
+	<action fromid="37044" toid="37045" script="others/alchemy.lua" />
 </actions>

--- a/data/scripts/actions/others/alchemy.lua
+++ b/data/scripts/actions/others/alchemy.lua
@@ -1,0 +1,69 @@
+-- Alchemy system action
+
+local alchemy = Action()
+
+-- load recipes
+if not ALCHEMY_RECIPES then
+    dofile('data/scripts/alchemy/recipes.lua')
+end
+
+local function matchRecipe(ids)
+    table.sort(ids)
+    for _, recipe in pairs(ALCHEMY_RECIPES) do
+        local rids = { table.unpack(recipe.ingredients) }
+        table.sort(rids)
+        if #ids == #rids then
+            local ok = true
+            for i = 1, #rids do
+                if rids[i] ~= ids[i] then
+                    ok = false
+                    break
+                end
+            end
+            if ok then
+                return recipe
+            end
+        end
+    end
+end
+
+function alchemy.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+    local container = item:getContainer()
+    if not container then
+        player:sendCancelMessage("You need to use this on a container.")
+        return true
+    end
+
+    local ids = {}
+    for i = 0, container:getSize() - 1 do
+        local ingredient = container:getItem(i)
+        if ingredient then
+            ids[#ids + 1] = ingredient.itemid
+        end
+    end
+
+    if #ids == 0 then
+        return true
+    end
+
+    local recipe = matchRecipe(ids)
+    if not recipe then
+        player:sendCancelMessage("Those ingredients do not form a known potion.")
+        return true
+    end
+
+    -- remove ingredients
+    for i = container:getSize() - 1, 0, -1 do
+        local ingredient = container:getItem(i)
+        if ingredient then
+            ingredient:remove()
+        end
+    end
+
+    container:addItem(recipe.result, 1)
+    player:sendTextMessage(MESSAGE_EVENT_ADVANCE, recipe.message or "You mix the ingredients.")
+    return true
+end
+
+alchemy:id(37044, 37045)
+alchemy:register()

--- a/data/scripts/alchemy/recipes.lua
+++ b/data/scripts/alchemy/recipes.lua
@@ -1,0 +1,14 @@
+-- Configuration for the alchemy system
+
+ALCHEMY_RECIPES = {
+    {
+        ingredients = {2148, 2671}, -- gold coin + ham
+        result = 7618, -- health potion
+        message = "You brew a health potion."
+    },
+    {
+        ingredients = {2152, 2149}, -- platinum coin + small emerald
+        result = 7620, -- mana potion
+        message = "You brew a mana potion."
+    }
+}

--- a/docs/alchemy.md
+++ b/docs/alchemy.md
@@ -1,0 +1,31 @@
+# Alchemy System
+
+This system lets players brew potions using common loot items. Recipes are defined in a Lua configuration file so new combinations can be added without touching the main script.
+
+## Files
+
+- `data/scripts/alchemy/recipes.lua` – defines available recipes.
+- `data/scripts/actions/others/alchemy.lua` – handles player interaction.
+- `data/actions/actions.xml` – registers the alchemy shelf action.
+
+## Usage
+
+1. Put the ingredients into an **alchemy shelf** (item IDs `37044` or `37045`).
+2. Use the shelf. If the contents match a recipe, the items are consumed and the shelf will produce the result potion.
+
+## Adding Recipes
+
+Edit `data/scripts/alchemy/recipes.lua`. Each recipe entry has:
+
+```lua
+{
+    ingredients = { -- list of item IDs
+        2148, 2671
+    },
+    result = 7618,      -- item ID of the created potion
+    message = "You brew a health potion." -- optional text shown to the player
+}
+```
+
+Include any number of ingredient IDs. The order of ingredients inside the shelf does not matter, but the shelf must contain exactly those items and nothing else.
+


### PR DESCRIPTION
## Summary
- implement a basic alchemy action script
- allow recipes to be configured in a separate file
- register alchemy shelf action in actions.xml
- document the system in a new docs file

## Testing
- `find data/ -name '*.lua' -print0 | xargs -0 -n1 luac -p`
- `luacheck data config.lua.dist`
- `find data/ -name '*.xml' -print0 | xargs -0 -n1 xmllint --noout`
- `luarocks install --server=https://luarocks.org/dev luaformatter` *(failed: build error)*

------
https://chatgpt.com/codex/tasks/task_e_684f83c50be08332b74a1004eb4621fc