### PR TITLE
Add experimental classless system

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ forgottenserver [![Build Status](https://github.com/otland/forgottenserver/actio
 
 The Forgotten Server is a free and open-source MMORPG server emulator written in C++. It is a fork of the [OpenTibia Server](https://github.com/opentibia/server) project. To connect to the server, you can use [OTClient](https://github.com/mehah/otclient).
 
+An optional classless progression mode is described in `docs/classless.md`.
+
 ### Getting Started
 
 * [Compiling](https://github.com/otland/forgottenserver/wiki/Compiling), alternatively download [releases](https://github.com/otland/forgottenserver/releases)

--- a/config.lua.dist
+++ b/config.lua.dist
@@ -163,6 +163,10 @@ monsterGroupAttackScale = 20
 -- Percentage increase in monster defense per extra player
 monsterGroupDefenseScale = 20
 
+-- Classless system
+enableClasslessSystem = false
+pointsPerLevel = 5
+
 -- Stamina
 staminaSystem = true
 timeToRegenMinuteStamina = 3 * 60

--- a/docs/classless.md
+++ b/docs/classless.md
@@ -1,0 +1,12 @@
+# Classless System
+
+This repository includes an experimental classless character progression mode.
+When enabled through `enableClasslessSystem` in `config.lua`, players no longer
+gain stats from predefined vocations. Instead, each level grants a number of
+free points (configured by `pointsPerLevel`) which can be spent on custom
+attributes.
+
+Currently only health, mana and capacity can be increased. Points are stored in
+`Player::statPoints` and applied using `Player::spendStatPoint`. The feature is
+not integrated with spells or equipment restrictions and should be considered a
+work in progress.

--- a/src/classless.h
+++ b/src/classless.h
@@ -1,0 +1,47 @@
+#ifndef FS_CLASSLESS_H
+#define FS_CLASSLESS_H
+
+#include <cstdint>
+
+enum class StatAttribute : uint8_t {
+    HEALTH,
+    MANA,
+    CAPACITY,
+    LAST
+};
+
+struct ClasslessStats {
+    uint16_t health = 0;
+    uint16_t mana = 0;
+    uint16_t capacity = 0;
+
+    uint16_t& get(StatAttribute attr)
+    {
+        switch (attr) {
+            case StatAttribute::HEALTH:
+                return health;
+            case StatAttribute::MANA:
+                return mana;
+            case StatAttribute::CAPACITY:
+                return capacity;
+            default:
+                return health; // fallback
+        }
+    }
+
+    uint16_t get(const StatAttribute attr) const
+    {
+        switch (attr) {
+            case StatAttribute::HEALTH:
+                return health;
+            case StatAttribute::MANA:
+                return mana;
+            case StatAttribute::CAPACITY:
+                return capacity;
+            default:
+                return 0;
+        }
+    }
+};
+
+#endif // FS_CLASSLESS_H

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -246,6 +246,7 @@ bool ConfigManager::load()
         boolean[CHECK_DUPLICATE_STORAGE_KEYS] = getGlobalBoolean(L, "checkDuplicateStorageKeys", false);
         boolean[MONSTER_OVERSPAWN] = getGlobalBoolean(L, "monsterOverspawn", false);
        boolean[MONSTER_GROUP_SCALING] = getGlobalBoolean(L, "monsterGroupScaling", false);
+       boolean[ENABLE_CLASSLESS_SYSTEM] = getGlobalBoolean(L, "enableClasslessSystem", false);
 
 	string[DEFAULT_PRIORITY] = getGlobalString(L, "defaultPriority", "high");
 	string[SERVER_NAME] = getGlobalString(L, "serverName", "");
@@ -297,6 +298,7 @@ bool ConfigManager::load()
         integer[PATHFINDING_DELAY] = getGlobalNumber(L, "pathfindingDelay", 300);
        integer[MONSTER_GROUP_ATTACK_SCALE] = getGlobalNumber(L, "monsterGroupAttackScale", 20);
        integer[MONSTER_GROUP_DEFENSE_SCALE] = getGlobalNumber(L, "monsterGroupDefenseScale", 20);
+       integer[POINTS_PER_LEVEL] = getGlobalNumber(L, "pointsPerLevel", 5);
 
 	expStages = loadXMLStages();
 	if (expStages.empty()) {

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -48,6 +48,7 @@ enum boolean_config_t
        CHECK_DUPLICATE_STORAGE_KEYS,
        MONSTER_OVERSPAWN,
        MONSTER_GROUP_SCALING,
+       ENABLE_CLASSLESS_SYSTEM,
 
        LAST_BOOLEAN_CONFIG /* this must be the last one */
 };
@@ -126,6 +127,7 @@ enum integer_config_t
        PATHFINDING_DELAY,
        MONSTER_GROUP_ATTACK_SCALE,
        MONSTER_GROUP_DEFENSE_SCALE,
+       POINTS_PER_LEVEL,
 
        LAST_INTEGER_CONFIG /* this must be the last one */
 };

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1751,13 +1751,17 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText /* = fa
 	experience += exp;
 
 	uint32_t prevLevel = level;
-	while (experience >= nextLevelExp) {
-		++level;
-		healthMax += vocation->getHPGain();
-		health += vocation->getHPGain();
-		manaMax += vocation->getManaGain();
-		mana += vocation->getManaGain();
-		capacity += vocation->getCapGain();
+       while (experience >= nextLevelExp) {
+               ++level;
+               if (ConfigManager::getBoolean(ConfigManager::ENABLE_CLASSLESS_SYSTEM)) {
+                       statPoints += ConfigManager::getNumber(ConfigManager::POINTS_PER_LEVEL);
+               } else {
+                       healthMax += vocation->getHPGain();
+                       health += vocation->getHPGain();
+                       manaMax += vocation->getManaGain();
+                       mana += vocation->getManaGain();
+                       capacity += vocation->getCapGain();
+               }
 
 		currLevelExp = nextLevelExp;
 		nextLevelExp = Player::getExpForLevel(level + 1);

--- a/src/player.h
+++ b/src/player.h
@@ -15,6 +15,7 @@
 #include "protocolgame.h"
 #include "town.h"
 #include "vocation.h"
+#include "classless.h"
 
 class House;
 struct Mount;
@@ -321,7 +322,7 @@ public:
 		} else if (hasFlag(PlayerFlag_HasInfiniteCapacity)) {
 			return std::numeric_limits<uint32_t>::max();
 		}
-		return capacity;
+               return capacity + classlessStats.capacity;
 	}
 
 	uint32_t getFreeCapacity() const
@@ -331,12 +332,12 @@ public:
 		} else if (hasFlag(PlayerFlag_HasInfiniteCapacity)) {
 			return std::numeric_limits<uint32_t>::max();
 		}
-		return std::max<int32_t>(0, capacity - inventoryWeight);
+               return std::max<int32_t>(0, capacity + classlessStats.capacity - inventoryWeight);
 	}
 
-	int32_t getMaxHealth() const override { return std::max<int32_t>(1, healthMax + varStats[STAT_MAXHITPOINTS]); }
-	uint32_t getMana() const { return mana; }
-	uint32_t getMaxMana() const { return std::max<int32_t>(0, manaMax + varStats[STAT_MAXMANAPOINTS]); }
+       int32_t getMaxHealth() const override { return std::max<int32_t>(1, healthMax + varStats[STAT_MAXHITPOINTS] + classlessStats.health); }
+       uint32_t getMana() const { return mana; }
+       uint32_t getMaxMana() const { return std::max<int32_t>(0, manaMax + varStats[STAT_MAXMANAPOINTS] + classlessStats.mana); }
 	uint16_t getManaShieldBar() const { return manaShieldBar; }
 	void setManaShieldBar(uint16_t value) { manaShieldBar = value; }
 	uint16_t getMaxManaShieldBar() const { return maxManaShieldBar; }
@@ -356,9 +357,19 @@ public:
 		specialMagicLevelSkill[combatTypeToIndex(type)] += modifier;
 	}
 
-	void setVarStats(stats_t stat, int32_t modifier);
+        void setVarStats(stats_t stat, int32_t modifier);
 
-	int32_t getDefaultStats(stats_t stat) const;
+        bool spendStatPoint(StatAttribute attr)
+        {
+                if (statPoints == 0) {
+                        return false;
+                }
+                ++classlessStats.get(attr);
+                --statPoints;
+                return true;
+        }
+
+        int32_t getDefaultStats(stats_t stat) const;
 
 	void addConditionSuppressions(uint32_t conditions);
 	void removeConditionSuppressions(uint32_t conditions);
@@ -1200,8 +1211,10 @@ private:
 	time_t lastLogout = 0;
 	time_t premiumEndsAt = 0;
 
-	uint64_t experience = 0;
-	uint64_t manaSpent = 0;
+        uint64_t experience = 0;
+       uint32_t statPoints = 0;
+       ClasslessStats classlessStats;
+        uint64_t manaSpent = 0;
 	uint64_t lastAttack = 0;
 	uint64_t bankBalance = 0;
 	int64_t lastFailedFollow = 0;


### PR DESCRIPTION
## Summary
- describe new optional classless progression in README
- allow enabling classless mode from config
- grant players stat points instead of vocation stats on level up
- track allocated points on each player
- document feature in new `docs/classless.md`

## Testing
- `cmake ..`
- `cmake --build .`

------
https://chatgpt.com/codex/tasks/task_e_684f910bbfa483328bdf3a55680da6aa