### PR TITLE
Add readable names for new crafting skills

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -692,6 +692,15 @@ std::string getSkillName(uint8_t skillid)
 		case SKILL_FISHING:
 			return "fishing";
 
+		case SKILL_BLACKSMITHING:
+			return "blacksmithing";
+
+		case SKILL_FARMING:
+			return "farming";
+
+		case SKILL_JEWELCRAFTING:
+			return "jewelcrafting";
+
 		case SKILL_MAGLEVEL:
 			return "magic level";
 


### PR DESCRIPTION
## Summary
- add missing skill names to `getSkillName`

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_684f9bcffe808332947c8cc69b666a86