### PR TITLE
Refactor spawn ownership with shared_ptr

### DIFF
--- a/src/spawn.h
+++ b/src/spawn.h
@@ -5,6 +5,7 @@
 #define FS_SPAWN_H
 
 #include "position.h"
+#include <memory>
 
 class Monster;
 class MonsterType;
@@ -44,8 +45,8 @@ public:
 
 private:
 	// map of the spawned creatures
-	using SpawnedMap = std::multimap<uint32_t, Monster*>;
-	SpawnedMap spawnedMap;
+        using SpawnedMap = std::multimap<uint32_t, std::shared_ptr<Monster>>;
+        SpawnedMap spawnedMap;
 
 	// map of creatures in the spawn
 	std::map<uint32_t, spawnBlock_t> spawnMap;


### PR DESCRIPTION
## Summary
- use `std::shared_ptr` for spawned monsters
- clean up destructor and helper routines

## Testing
- `cmake --build build -j 2` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6852fc832ae48332904c3a97f7f97418