### PR TITLE
Assign unique spell IDs for custom scripts

### DIFF
--- a/data/scripts/spells/attack/frost_nova.lua
+++ b/data/scripts/spells/attack/frost_nova.lua
@@ -18,7 +18,7 @@ function spell.onCastSpell(creature, variant)
 end
 
 spell:group("attack")
-spell:id(309)
+spell:id(187)
 spell:name("Frost Nova")
 spell:words("exevo frigo mas")
 spell:level(30)

--- a/data/scripts/spells/attack/shadow_bolt.lua
+++ b/data/scripts/spells/attack/shadow_bolt.lua
@@ -18,7 +18,7 @@ function spell.onCastSpell(creature, variant)
 end
 
 spell:group("attack")
-spell:id(310)
+spell:id(188)
 spell:name("Shadow Bolt")
 spell:words("exori mort hur")
 spell:level(24)

--- a/data/scripts/spells/attack/star_fire.lua
+++ b/data/scripts/spells/attack/star_fire.lua
@@ -18,7 +18,7 @@ function spell.onCastSpell(creature, variant)
 end
 
 spell:group("attack")
-spell:id(312)
+spell:id(190)
 spell:name("Star Fire")
 spell:words("exori stellar flam")
 spell:level(40)

--- a/data/scripts/spells/attack/stone_spikes.lua
+++ b/data/scripts/spells/attack/stone_spikes.lua
@@ -19,7 +19,7 @@ function spell.onCastSpell(creature, variant)
 end
 
 spell:group("attack")
-spell:id(311)
+spell:id(189)
 spell:name("Stone Spikes")
 spell:words("exori tera mas")
 spell:level(32)

--- a/data/scripts/spells/attack/toxic_cloud.lua
+++ b/data/scripts/spells/attack/toxic_cloud.lua
@@ -19,7 +19,7 @@ function spell.onCastSpell(creature, variant)
 end
 
 spell:group("attack")
-spell:id(313)
+spell:id(191)
 spell:name("Toxic Cloud")
 spell:words("exevo mortera")
 spell:level(28)

--- a/data/scripts/spells/attack/wind_slash.lua
+++ b/data/scripts/spells/attack/wind_slash.lua
@@ -18,7 +18,7 @@ function spell.onCastSpell(creature, variant)
 end
 
 spell:group("attack")
-spell:id(308)
+spell:id(186)
 spell:name("Wind Slash")
 spell:words("exori ventus")
 spell:level(18)

--- a/data/scripts/spells/attributes/agility.lua
+++ b/data/scripts/spells/attributes/agility.lua
@@ -4,7 +4,7 @@ function spell.onCastSpell(creature, variant)
         return true
 end
 spell:group("support")
-spell:id(302)
+spell:id(180)
 spell:name("Check Agility")
 spell:words("exiva agi")
 spell:level(1)

--- a/data/scripts/spells/attributes/charisma.lua
+++ b/data/scripts/spells/attributes/charisma.lua
@@ -4,7 +4,7 @@ function spell.onCastSpell(creature, variant)
         return true
 end
 spell:group("support")
-spell:id(306)
+spell:id(184)
 spell:name("Check Charisma")
 spell:words("exiva cha")
 spell:level(1)

--- a/data/scripts/spells/attributes/intelligence.lua
+++ b/data/scripts/spells/attributes/intelligence.lua
@@ -4,7 +4,7 @@ function spell.onCastSpell(creature, variant)
         return true
 end
 spell:group("support")
-spell:id(304)
+spell:id(182)
 spell:name("Check Intelligence")
 spell:words("exiva int")
 spell:level(1)

--- a/data/scripts/spells/attributes/luck.lua
+++ b/data/scripts/spells/attributes/luck.lua
@@ -4,7 +4,7 @@ function spell.onCastSpell(creature, variant)
         return true
 end
 spell:group("support")
-spell:id(305)
+spell:id(183)
 spell:name("Check Luck")
 spell:words("exiva luc")
 spell:level(1)

--- a/data/scripts/spells/attributes/spirit.lua
+++ b/data/scripts/spells/attributes/spirit.lua
@@ -4,7 +4,7 @@ function spell.onCastSpell(creature, variant)
         return true
 end
 spell:group("support")
-spell:id(307)
+spell:id(185)
 spell:name("Check Spirit")
 spell:words("exiva spi")
 spell:level(1)

--- a/data/scripts/spells/attributes/strength.lua
+++ b/data/scripts/spells/attributes/strength.lua
@@ -4,7 +4,7 @@ function spell.onCastSpell(creature, variant)
         return true
 end
 spell:group("support")
-spell:id(301)
+spell:id(179)
 spell:name("Check Strength")
 spell:words("exiva str")
 spell:level(1)

--- a/data/scripts/spells/attributes/vitality.lua
+++ b/data/scripts/spells/attributes/vitality.lua
@@ -4,7 +4,7 @@ function spell.onCastSpell(creature, variant)
         return true
 end
 spell:group("support")
-spell:id(303)
+spell:id(181)
 spell:name("Check Vitality")
 spell:words("exiva vit")
 spell:level(1)

--- a/data/scripts/spells/healing/healing_wave.lua
+++ b/data/scripts/spells/healing/healing_wave.lua
@@ -18,7 +18,7 @@ function spell.onCastSpell(creature, variant)
 end
 
 spell:group("healing")
-spell:id(317)
+spell:id(195)
 spell:name("Healing Wave")
 spell:words("exura mas sio")
 spell:level(34)

--- a/data/scripts/spells/healing/mana_flourish.lua
+++ b/data/scripts/spells/healing/mana_flourish.lua
@@ -16,7 +16,7 @@ function spell.onCastSpell(creature, variant)
 end
 
 spell:group("healing")
-spell:id(316)
+spell:id(194)
 spell:name("Mana Flourish")
 spell:words("utura mana")
 spell:level(20)

--- a/data/scripts/spells/support/holy_barrier.lua
+++ b/data/scripts/spells/support/holy_barrier.lua
@@ -15,7 +15,7 @@ function spell.onCastSpell(creature, variant)
 end
 
 spell:group("support")
-spell:id(314)
+spell:id(192)
 spell:name("Holy Barrier")
 spell:words("utamo sancta")
 spell:level(24)

--- a/data/scripts/spells/support/speed_boost.lua
+++ b/data/scripts/spells/support/speed_boost.lua
@@ -14,7 +14,7 @@ function spell.onCastSpell(creature, variant)
 end
 
 spell:group("support")
-spell:id(315)
+spell:id(193)
 spell:name("Speed Boost")
 spell:words("utani tempo lux")
 spell:level(20)


### PR DESCRIPTION
## Summary
- Allocate distinct spell IDs 179–195 for attribute, attack, support, and healing scripts
- Prevent ID collisions by verifying no duplicates across `data/scripts/spells`

## Testing
- `rg -n "spell:id((179|18[0-9]|19[0-5])" data/scripts/spells | wc -l`
- `cmake .. -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake` *(fails: Could not find toolchain file `../vcpkg/scripts/buildsystems/vcpkg.cmake`)*

------
https://chatgpt.com/codex/tasks/task_e_68abad106cd0833297afa114f535ef8b